### PR TITLE
[UPDATE] improve formatting of replay controls in gameplay documentation

### DIFF
--- a/docs/docs/gameplay.md
+++ b/docs/docs/gameplay.md
@@ -62,8 +62,8 @@ Replays are **automatically recorded** during gameplay:
 2. Select a replay from the list (sorted by date)
 3. Use the playback controls:
    - **Pause/Play**: Pause or resume playback
-   - **<< Rewind**: Jump back 10 seconds
-   - **Forward >>**: Jump forward 10 seconds
+   - **`<<` Rewind**: Jump back 10 seconds
+   - **Forward `>>`**: Jump forward 10 seconds
    - **Speed**: Toggle between 0.5x, 1x, 2x playback speed
    - **Exit** or **ESC**: Return to replay browser
 


### PR DESCRIPTION
This pull request makes a minor documentation update to improve the clarity of the replay playback controls in the gameplay guide.

- Documentation improvement:
  * Updated the formatting of the rewind and forward playback controls in `docs/docs/gameplay.md` by enclosing `<<` and `>>` in backticks for better readability.