### PR TITLE
111 feat accesibility au clavier

### DIFF
--- a/client/Button.cpp
+++ b/client/Button.cpp
@@ -24,6 +24,7 @@ Button::Button(float x, float y, float width, float height,
       _isHovered(false),
       _wasPressed(false),
       _wasHovered(false),
+      _isFocused(false),
       _currentScale(1.0f),
       _targetScale(1.0f)
 {
@@ -48,7 +49,7 @@ bool Button::isClicked(int mouseX, int mouseY, bool isMousePressed)
                                                       HOVER_SOUND_VOLUME);
     }
     _wasHovered = _isHovered;
-    _targetScale = _isHovered ? HOVER_SCALE : NORMAL_SCALE;
+    _targetScale = (_isHovered || _isFocused) ? HOVER_SCALE : NORMAL_SCALE;
 
     bool clicked = false;
     if (_isHovered && isMousePressed) {

--- a/client/Button.hpp
+++ b/client/Button.hpp
@@ -63,6 +63,13 @@ class Button {
     float getHeight() const { return _height; }
     const std::string& getText() const { return _text; }
     bool getIsHovered() const { return _isHovered; }
+    bool getIsFocused() const { return _isFocused; }
+
+    /**
+     * @brief Set keyboard focus state
+     * @param focused True if button should be focused
+     */
+    void setFocused(bool focused) { _isFocused = focused; }
 
     /**
      * @brief Update hover animation
@@ -86,6 +93,7 @@ class Button {
     bool _isHovered;
     bool _wasPressed;
     bool _wasHovered;
+    bool _isFocused;
     float _currentScale;
     float _targetScale;
     static constexpr float HOVER_SCALE = 1.05f;

--- a/client/KeyBindingButton.hpp
+++ b/client/KeyBindingButton.hpp
@@ -60,6 +60,11 @@ class KeyBindingButton {
      */
     void setEditMode(bool edit) { _isInEditMode = edit; }
 
+    /**
+     * @brief Start edit mode (keyboard navigation)
+     */
+    void startEdit() { _isInEditMode = true; }
+
     // Getters for rendering
     float getX() const { return _x; }
     float getY() const { return _y; }

--- a/client/Menu.cpp
+++ b/client/Menu.cpp
@@ -121,12 +121,10 @@ MenuAction Menu::update(float deltaTime)
     int mouseY = _input.getMouseY();
     bool isMousePressed = _input.isMouseButtonPressed(MouseButton::Left);
 
-    // Gestion de la navigation au clavier
     bool isUpPressed = _input.isKeyPressed(Key::Up);
     bool isDownPressed = _input.isKeyPressed(Key::Down);
     bool isEnterPressed = _input.isKeyPressed(Key::Enter);
 
-    // Navigation avec les flèches
     if (isUpPressed && !_wasUpPressed) {
         _buttons[_selectedButtonIndex].setFocused(false);
         _selectedButtonIndex--;
@@ -158,8 +156,11 @@ MenuAction Menu::update(float deltaTime)
                 return MenuAction::None;
             case 1:
                 _wasEnterPressed = isEnterPressed;
-                return MenuAction::Settings;
+                return MenuAction::Replays;
             case 2:
+                _wasEnterPressed = isEnterPressed;
+                return MenuAction::Settings;
+            case 3:
                 _wasEnterPressed = isEnterPressed;
                 return MenuAction::Quit;
         }

--- a/client/Menu.hpp
+++ b/client/Menu.hpp
@@ -81,6 +81,9 @@ class Menu {
     {
         _isFadingOut = false;
         _uiAlpha = 1.0f;
+        _wasUpPressed = true;
+        _wasDownPressed = true;
+        _wasEnterPressed = true;
     }
 
    private:

--- a/client/Menu.hpp
+++ b/client/Menu.hpp
@@ -87,6 +87,11 @@ class Menu {
     std::string _fontPath;
     ColorBlindFilter& _colorBlindFilter;
 
+    int _selectedButtonIndex;
+    bool _wasUpPressed;
+    bool _wasDownPressed;
+    bool _wasEnterPressed;
+
     bool _isFadingOut;
     float _uiAlpha;
     static constexpr float FADE_SPEED = 2.0f;

--- a/client/ReplayBrowser.cpp
+++ b/client/ReplayBrowser.cpp
@@ -685,8 +685,7 @@ void ReplayBrowser::showDeleteDialog(size_t replayIndex)
 {
     _selectedReplayIndex = replayIndex;
     _showDeleteDialog = true;
-    _dialogFocusedButton =
-        1;
+    _dialogFocusedButton = 1;
 }
 
 void ReplayBrowser::handleRenameConfirm()

--- a/client/ReplayBrowser.cpp
+++ b/client/ReplayBrowser.cpp
@@ -235,8 +235,7 @@ void ReplayBrowser::update(float deltaTime)
     bool isEnterPressed = _input.isKeyPressed(Key::Enter);
     bool isEscapePressed = _input.isKeyPressed(Key::Escape);
 
-    int totalRows =
-        static_cast<int>(_replayButtons.size()) + 1;
+    int totalRows = static_cast<int>(_replayButtons.size()) + 1;
     int maxColumns = _replayButtons.empty() ? 1 : 3;
 
     if (isUpPressed && !_wasUpPressed) {

--- a/client/ReplayBrowser.cpp
+++ b/client/ReplayBrowser.cpp
@@ -34,7 +34,16 @@ ReplayBrowser::ReplayBrowser(WindowSFML& window, GraphicsSFML& graphics,
       _renameInputField(0, 0, 440, 40, "", "", InputFieldType::Filename),
       _confirmButton(0, 0, 150, 40, "Confirm"),
       _cancelButton(0, 0, 150, 40, "Cancel"),
-      _keyWasPressed(static_cast<int>(Key::F12) + 1, false)
+      _dialogFocusedButton(0),
+      _keyWasPressed(static_cast<int>(Key::F12) + 1, false),
+      _focusedButtonIndex(0),
+      _focusedColumn(0),
+      _wasUpPressed(false),
+      _wasDownPressed(false),
+      _wasLeftPressed(false),
+      _wasRightPressed(false),
+      _wasEnterPressed(false),
+      _wasEscapePressed(false)
 {
     float windowWidth = static_cast<float>(_window.getWidth());
     float windowHeight = static_cast<float>(_window.getHeight());
@@ -69,6 +78,25 @@ void ReplayBrowser::update(float deltaTime)
 
     if (_showRenameDialog) {
         _renameInputField.update(mouseX, mouseY, isMousePressed);
+
+        bool isLeftPressed = _input.isKeyPressed(Key::Left);
+        bool isRightPressed = _input.isKeyPressed(Key::Right);
+        bool isEscapePressed = _input.isKeyPressed(Key::Escape);
+
+        if ((isLeftPressed && !_wasLeftPressed) ||
+            (isRightPressed && !_wasRightPressed)) {
+            _dialogFocusedButton = (_dialogFocusedButton == 0) ? 1 : 0;
+        }
+        _wasLeftPressed = isLeftPressed;
+        _wasRightPressed = isRightPressed;
+
+        if (isEscapePressed && !_wasEscapePressed) {
+            _showRenameDialog = false;
+            _renameInputField.setValue("");
+            _wasEscapePressed = isEscapePressed;
+            return;
+        }
+        _wasEscapePressed = isEscapePressed;
 
         for (int key = static_cast<int>(Key::A);
              key <= static_cast<int>(Key::Z); ++key) {
@@ -105,10 +133,23 @@ void ReplayBrowser::update(float deltaTime)
 
         bool enterPressed = _input.isKeyPressed(Key::Enter);
         if (enterPressed && !_keyWasPressed[static_cast<int>(Key::Enter)]) {
-            handleRenameConfirm();
+            if (_dialogFocusedButton == 0) {
+                handleRenameConfirm();
+            } else {
+                _showRenameDialog = false;
+                _renameInputField.setValue("");
+            }
+            _keyWasPressed[static_cast<int>(Key::Enter)] = enterPressed;
             return;
         }
         _keyWasPressed[static_cast<int>(Key::Enter)] = enterPressed;
+
+        if (_confirmButton.isHovered(mouseX, mouseY)) {
+            _dialogFocusedButton = 0;
+        }
+        if (_cancelButton.isHovered(mouseX, mouseY)) {
+            _dialogFocusedButton = 1;
+        }
 
         if (_confirmButton.isClicked(mouseX, mouseY, isMousePressed)) {
             handleRenameConfirm();
@@ -123,6 +164,43 @@ void ReplayBrowser::update(float deltaTime)
     }
 
     if (_showDeleteDialog) {
+        bool isLeftPressed = _input.isKeyPressed(Key::Left);
+        bool isRightPressed = _input.isKeyPressed(Key::Right);
+        bool isEnterPressed = _input.isKeyPressed(Key::Enter);
+        bool isEscapePressed = _input.isKeyPressed(Key::Escape);
+
+        if ((isLeftPressed && !_wasLeftPressed) ||
+            (isRightPressed && !_wasRightPressed)) {
+            _dialogFocusedButton = (_dialogFocusedButton == 0) ? 1 : 0;
+        }
+        _wasLeftPressed = isLeftPressed;
+        _wasRightPressed = isRightPressed;
+
+        if (isEscapePressed && !_wasEscapePressed) {
+            _showDeleteDialog = false;
+            _wasEscapePressed = isEscapePressed;
+            return;
+        }
+        _wasEscapePressed = isEscapePressed;
+
+        if (isEnterPressed && !_wasEnterPressed) {
+            if (_dialogFocusedButton == 0) {
+                handleDeleteConfirm();
+            } else {
+                _showDeleteDialog = false;
+            }
+            _wasEnterPressed = isEnterPressed;
+            return;
+        }
+        _wasEnterPressed = isEnterPressed;
+
+        if (_confirmButton.isHovered(mouseX, mouseY)) {
+            _dialogFocusedButton = 0;
+        }
+        if (_cancelButton.isHovered(mouseX, mouseY)) {
+            _dialogFocusedButton = 1;
+        }
+
         if (_confirmButton.isClicked(mouseX, mouseY, isMousePressed)) {
             handleDeleteConfirm();
             return;
@@ -148,6 +226,106 @@ void ReplayBrowser::update(float deltaTime)
     if (_backButton.isClicked(mouseX, mouseY, isMousePressed)) {
         _wantsBack = true;
         return;
+    }
+
+    bool isUpPressed = _input.isKeyPressed(Key::Up);
+    bool isDownPressed = _input.isKeyPressed(Key::Down);
+    bool isLeftPressed = _input.isKeyPressed(Key::Left);
+    bool isRightPressed = _input.isKeyPressed(Key::Right);
+    bool isEnterPressed = _input.isKeyPressed(Key::Enter);
+    bool isEscapePressed = _input.isKeyPressed(Key::Escape);
+
+    int totalRows =
+        static_cast<int>(_replayButtons.size()) + 1;
+    int maxColumns = _replayButtons.empty() ? 1 : 3;
+
+    if (isUpPressed && !_wasUpPressed) {
+        _focusedButtonIndex--;
+        if (_focusedButtonIndex < 0) {
+            _focusedButtonIndex = totalRows - 1;
+        }
+        if (_focusedButtonIndex == static_cast<int>(_replayButtons.size())) {
+            _focusedColumn = 0;
+        }
+    }
+    if (isDownPressed && !_wasDownPressed) {
+        _focusedButtonIndex++;
+        if (_focusedButtonIndex >= totalRows) {
+            _focusedButtonIndex = 0;
+        }
+        if (_focusedButtonIndex == static_cast<int>(_replayButtons.size())) {
+            _focusedColumn = 0;
+        }
+    }
+    if (_focusedButtonIndex < static_cast<int>(_replayButtons.size())) {
+        if (isLeftPressed && !_wasLeftPressed) {
+            _focusedColumn--;
+            if (_focusedColumn < 0) {
+                _focusedColumn = maxColumns - 1;
+            }
+        }
+        if (isRightPressed && !_wasRightPressed) {
+            _focusedColumn++;
+            if (_focusedColumn >= maxColumns) {
+                _focusedColumn = 0;
+            }
+        }
+    }
+
+    if (isEscapePressed && !_wasEscapePressed) {
+        _wantsBack = true;
+        _wasEscapePressed = isEscapePressed;
+        return;
+    }
+
+    if (isEnterPressed && !_wasEnterPressed) {
+        if (_focusedButtonIndex < static_cast<int>(_replayButtons.size())) {
+            switch (_focusedColumn) {
+                case 0:
+                    _selectedReplay = _replays[_focusedButtonIndex].fullPath;
+                    break;
+                case 1:
+                    showRenameDialog(_focusedButtonIndex);
+                    break;
+                case 2:
+                    showDeleteDialog(_focusedButtonIndex);
+                    break;
+            }
+        } else {
+            _wantsBack = true;
+        }
+        _wasEnterPressed = isEnterPressed;
+        return;
+    }
+
+    _wasUpPressed = isUpPressed;
+    _wasDownPressed = isDownPressed;
+    _wasLeftPressed = isLeftPressed;
+    _wasRightPressed = isRightPressed;
+    _wasEnterPressed = isEnterPressed;
+    _wasEscapePressed = isEscapePressed;
+
+    for (size_t i = 0; i < _replayButtons.size(); ++i) {
+        if (_replayButtons[i].isHovered(mouseX, mouseY)) {
+            _focusedButtonIndex = static_cast<int>(i);
+            _focusedColumn = 0;
+        }
+    }
+    for (size_t i = 0; i < _renameButtons.size(); ++i) {
+        if (_renameButtons[i].isHovered(mouseX, mouseY)) {
+            _focusedButtonIndex = static_cast<int>(i);
+            _focusedColumn = 1;
+        }
+    }
+    for (size_t i = 0; i < _deleteButtons.size(); ++i) {
+        if (_deleteButtons[i].isHovered(mouseX, mouseY)) {
+            _focusedButtonIndex = static_cast<int>(i);
+            _focusedColumn = 2;
+        }
+    }
+    if (_backButton.isHovered(mouseX, mouseY)) {
+        _focusedButtonIndex = static_cast<int>(_replayButtons.size());
+        _focusedColumn = 0;
     }
 
     for (size_t i = 0; i < _replayButtons.size(); ++i) {
@@ -196,10 +374,12 @@ void ReplayBrowser::render()
 
     for (size_t i = 0; i < _replayButtons.size(); ++i) {
         bool isHovered = _replayButtons[i].isHovered(mouseX, mouseY);
+        bool isFocused =
+            (_focusedButtonIndex == static_cast<int>(i) && _focusedColumn == 0);
 
-        unsigned char r = isHovered ? 0 : 30;
-        unsigned char g = isHovered ? 200 : 30;
-        unsigned char b = isHovered ? 255 : 100;
+        unsigned char r = (isHovered || isFocused) ? 0 : 30;
+        unsigned char g = (isHovered || isFocused) ? 200 : 30;
+        unsigned char b = (isHovered || isFocused) ? 255 : 100;
 
         float buttonX = _replayButtons[i].getX();
         float buttonY = _replayButtons[i].getY();
@@ -228,9 +408,11 @@ void ReplayBrowser::render()
                            255, 255, 255, "");
 
         bool renameHovered = _renameButtons[i].isHovered(mouseX, mouseY);
-        r = renameHovered ? 255 : 50;
-        g = renameHovered ? 200 : 100;
-        b = renameHovered ? 0 : 50;
+        bool renameFocused =
+            (_focusedButtonIndex == static_cast<int>(i) && _focusedColumn == 1);
+        r = (renameHovered || renameFocused) ? 255 : 50;
+        g = (renameHovered || renameFocused) ? 200 : 100;
+        b = (renameHovered || renameFocused) ? 0 : 50;
 
         float renameX = _renameButtons[i].getX();
         float renameY = _renameButtons[i].getY();
@@ -256,9 +438,11 @@ void ReplayBrowser::render()
                            "");
 
         bool deleteHovered = _deleteButtons[i].isHovered(mouseX, mouseY);
-        r = deleteHovered ? 255 : 100;
-        g = deleteHovered ? 50 : 30;
-        b = deleteHovered ? 50 : 30;
+        bool deleteFocused =
+            (_focusedButtonIndex == static_cast<int>(i) && _focusedColumn == 2);
+        r = (deleteHovered || deleteFocused) ? 255 : 100;
+        g = (deleteHovered || deleteFocused) ? 50 : 30;
+        b = (deleteHovered || deleteFocused) ? 50 : 30;
 
         float deleteX = _deleteButtons[i].getX();
         float deleteY = _deleteButtons[i].getY();
@@ -293,9 +477,11 @@ void ReplayBrowser::render()
 
     float borderThickness = 3.0f;
     bool isHovered = _backButton.isHovered(mouseX, mouseY);
-    unsigned char r = isHovered ? 0 : 30;
-    unsigned char g = isHovered ? 200 : 30;
-    unsigned char b = isHovered ? 255 : 100;
+    bool isBackFocused =
+        (_focusedButtonIndex == static_cast<int>(_replayButtons.size()));
+    unsigned char r = (isHovered || isBackFocused) ? 0 : 30;
+    unsigned char g = (isHovered || isBackFocused) ? 200 : 30;
+    unsigned char b = (isHovered || isBackFocused) ? 255 : 100;
 
     float backX = _backButton.getX();
     float backY = _backButton.getY();
@@ -487,6 +673,7 @@ void ReplayBrowser::showRenameDialog(size_t replayIndex)
 {
     _selectedReplayIndex = replayIndex;
     _showRenameDialog = true;
+    _dialogFocusedButton = 0;  // Focus sur Confirm par défaut
     std::string fileName = _replays[replayIndex].fileName;
     if (fileName.size() > 4 && fileName.substr(fileName.size() - 4) == ".rtr") {
         fileName = fileName.substr(0, fileName.size() - 4);
@@ -499,6 +686,8 @@ void ReplayBrowser::showDeleteDialog(size_t replayIndex)
 {
     _selectedReplayIndex = replayIndex;
     _showDeleteDialog = true;
+    _dialogFocusedButton =
+        1;  // Focus sur Cancel par défaut (plus sécurisé pour delete)
 }
 
 void ReplayBrowser::handleRenameConfirm()
@@ -598,9 +787,10 @@ void ReplayBrowser::renderRenameDialog()
     int mouseY = _input.getMouseY();
 
     bool confirmHovered = _confirmButton.isHovered(mouseX, mouseY);
-    unsigned char r = confirmHovered ? 0 : 50;
-    unsigned char g = confirmHovered ? 255 : 150;
-    unsigned char b = confirmHovered ? 0 : 50;
+    bool confirmFocused = (_dialogFocusedButton == 0);
+    unsigned char r = (confirmHovered || confirmFocused) ? 0 : 50;
+    unsigned char g = (confirmHovered || confirmFocused) ? 255 : 150;
+    unsigned char b = (confirmHovered || confirmFocused) ? 0 : 50;
 
     _graphics.drawRectangle(_confirmButton.getX(), _confirmButton.getY(),
                             _confirmButton.getWidth(),
@@ -615,9 +805,10 @@ void ReplayBrowser::renderRenameDialog()
                        255, "");
 
     bool cancelHovered = _cancelButton.isHovered(mouseX, mouseY);
-    r = cancelHovered ? 255 : 100;
-    g = cancelHovered ? 100 : 50;
-    b = cancelHovered ? 100 : 50;
+    bool cancelFocused = (_dialogFocusedButton == 1);
+    r = (cancelHovered || cancelFocused) ? 255 : 100;
+    g = (cancelHovered || cancelFocused) ? 100 : 50;
+    b = (cancelHovered || cancelFocused) ? 100 : 50;
 
     _graphics.drawRectangle(_cancelButton.getX(), _cancelButton.getY(),
                             _cancelButton.getWidth(), _cancelButton.getHeight(),
@@ -668,9 +859,10 @@ void ReplayBrowser::renderDeleteDialog()
     int mouseY = _input.getMouseY();
 
     bool confirmHovered = _confirmButton.isHovered(mouseX, mouseY);
-    unsigned char r = confirmHovered ? 255 : 150;
-    unsigned char g = confirmHovered ? 50 : 30;
-    unsigned char b = confirmHovered ? 50 : 30;
+    bool confirmFocused = (_dialogFocusedButton == 0);
+    unsigned char r = (confirmHovered || confirmFocused) ? 255 : 150;
+    unsigned char g = (confirmHovered || confirmFocused) ? 50 : 30;
+    unsigned char b = (confirmHovered || confirmFocused) ? 50 : 30;
 
     _graphics.drawRectangle(_confirmButton.getX(), _confirmButton.getY(),
                             _confirmButton.getWidth(),
@@ -685,9 +877,10 @@ void ReplayBrowser::renderDeleteDialog()
                        255, "");
 
     bool cancelHovered = _cancelButton.isHovered(mouseX, mouseY);
-    r = cancelHovered ? 100 : 50;
-    g = cancelHovered ? 150 : 100;
-    b = cancelHovered ? 100 : 50;
+    bool cancelFocused = (_dialogFocusedButton == 1);
+    r = (cancelHovered || cancelFocused) ? 100 : 50;
+    g = (cancelHovered || cancelFocused) ? 150 : 100;
+    b = (cancelHovered || cancelFocused) ? 100 : 50;
 
     _graphics.drawRectangle(_cancelButton.getX(), _cancelButton.getY(),
                             _cancelButton.getWidth(), _cancelButton.getHeight(),
@@ -747,6 +940,15 @@ void ReplayBrowser::reset()
     _showRenameDialog = false;
     _showDeleteDialog = false;
     _showErrorDialog = false;
+    _focusedButtonIndex = 0;
+    _focusedColumn = 0;
+    _wasUpPressed = false;
+    _wasDownPressed = false;
+    _wasLeftPressed = false;
+    _wasRightPressed = false;
+    _wasEnterPressed = true;  // Évite l'activation immédiate
+    _wasEscapePressed = false;
+    refreshReplayList();
 }
 
 }  // namespace rtype

--- a/client/ReplayBrowser.cpp
+++ b/client/ReplayBrowser.cpp
@@ -672,7 +672,7 @@ void ReplayBrowser::showRenameDialog(size_t replayIndex)
 {
     _selectedReplayIndex = replayIndex;
     _showRenameDialog = true;
-    _dialogFocusedButton = 0;  // Focus sur Confirm par défaut
+    _dialogFocusedButton = 0;
     std::string fileName = _replays[replayIndex].fileName;
     if (fileName.size() > 4 && fileName.substr(fileName.size() - 4) == ".rtr") {
         fileName = fileName.substr(0, fileName.size() - 4);
@@ -686,7 +686,7 @@ void ReplayBrowser::showDeleteDialog(size_t replayIndex)
     _selectedReplayIndex = replayIndex;
     _showDeleteDialog = true;
     _dialogFocusedButton =
-        1;  // Focus sur Cancel par défaut (plus sécurisé pour delete)
+        1;
 }
 
 void ReplayBrowser::handleRenameConfirm()
@@ -945,7 +945,7 @@ void ReplayBrowser::reset()
     _wasDownPressed = false;
     _wasLeftPressed = false;
     _wasRightPressed = false;
-    _wasEnterPressed = true;  // Évite l'activation immédiate
+    _wasEnterPressed = true;
     _wasEscapePressed = false;
     refreshReplayList();
 }

--- a/client/ReplayBrowser.hpp
+++ b/client/ReplayBrowser.hpp
@@ -112,8 +112,18 @@ class ReplayBrowser {
     InputField _renameInputField;
     Button _confirmButton;
     Button _cancelButton;
+    int _dialogFocusedButton;
 
     std::vector<bool> _keyWasPressed;
+
+    int _focusedButtonIndex;
+    int _focusedColumn;
+    bool _wasUpPressed;
+    bool _wasDownPressed;
+    bool _wasLeftPressed;
+    bool _wasRightPressed;
+    bool _wasEnterPressed;
+    bool _wasEscapePressed;
 
     static constexpr float BUTTON_WIDTH = 450.0f;
     static constexpr float BUTTON_HEIGHT = 50.0f;

--- a/client/ReplayControls.hpp
+++ b/client/ReplayControls.hpp
@@ -65,6 +65,12 @@ class ReplayControls {
     std::vector<Button> _buttons;
     bool _wantsExit;
 
+    int _focusedButtonIndex;
+    bool _wasLeftPressed;
+    bool _wasRightPressed;
+    bool _wasEnterPressed;
+    bool _wasEscapePressed;
+
     enum ButtonIndex {
         PAUSE = 0,
         REWIND = 1,

--- a/client/SelectionButton.cpp
+++ b/client/SelectionButton.cpp
@@ -58,6 +58,23 @@ void SelectionButton::setSelectedIndex(int index)
     }
 }
 
+void SelectionButton::cycleNext()
+{
+    if (!_options.empty()) {
+        _selectedIndex = (_selectedIndex + 1) % _options.size();
+    }
+}
+
+void SelectionButton::cyclePrevious()
+{
+    if (!_options.empty()) {
+        _selectedIndex--;
+        if (_selectedIndex < 0) {
+            _selectedIndex = static_cast<int>(_options.size()) - 1;
+        }
+    }
+}
+
 std::string SelectionButton::getSelectedOption() const
 {
     if (_selectedIndex >= 0 &&

--- a/client/SelectionButton.hpp
+++ b/client/SelectionButton.hpp
@@ -59,6 +59,16 @@ class SelectionButton {
     void setSelectedIndex(int index);
 
     /**
+     * @brief Cycle to next option (keyboard navigation)
+     */
+    void cycleNext();
+
+    /**
+     * @brief Cycle to previous option (keyboard navigation)
+     */
+    void cyclePrevious();
+
+    /**
      * @brief Get current selected option text
      */
     std::string getSelectedOption() const;

--- a/client/SettingsMenu.cpp
+++ b/client/SettingsMenu.cpp
@@ -32,7 +32,17 @@ SettingsMenu::SettingsMenu(WindowSFML& window, GraphicsSFML& graphics,
       _config(Config::getInstance()),
       _keyBinding(KeyBinding::getInstance()),
       _colorBlindFilter(ColorBlindFilter::getInstance()),
-      _currentResolution(Resolution::R1920x1080)
+      _currentResolution(Resolution::R1920x1080),
+      _focusedElementIndex(0),
+      _totalFocusableElements(0),
+      _wasTabPressed(false),
+      _wasShiftPressed(false),
+      _wasEnterPressed(false),
+      _wasEscapePressed(false),
+      _wasLeftPressed(false),
+      _wasRightPressed(false),
+      _wasUpPressed(false),
+      _wasDownPressed(false)
 {
     setupBackground();
     setupSliders();
@@ -67,6 +77,9 @@ SettingsMenu::SettingsMenu(WindowSFML& window, GraphicsSFML& graphics,
         std::to_string(serverPort));
 
     updateLayout();
+    _totalFocusableElements =
+        static_cast<int>(_resolutionButtons.size() + _sliders.size() +
+                         _keyBindingButtons.size() + _inputFields.size() + 2);
 }
 
 void SettingsMenu::setupBackground()
@@ -235,7 +248,6 @@ void SettingsMenu::updateLayout()
     for (size_t i = 0; i < _inputFields.size(); i++) {
         std::string label = _inputFields[i].getLabel();
         std::string value = _inputFields[i].getValue();
-        // Preserve the field type when recreating (0=ServerIP, 1=ServerPort)
         InputFieldType type =
             (i == 0) ? InputFieldType::ServerIP : InputFieldType::ServerPort;
         _inputFields[i] =
@@ -261,6 +273,164 @@ bool SettingsMenu::update()
     int mouseY = _input.getMouseY();
     bool isMousePressed = _input.isMouseButtonPressed(MouseButton::Left);
     bool anyInEditMode = isWaitingForKeyPress();
+
+    bool isTabPressed = _input.isKeyPressed(Key::Tab);
+    bool isShiftPressed =
+        _input.isKeyPressed(Key::LShift) || _input.isKeyPressed(Key::RShift);
+    bool isEnterPressed = _input.isKeyPressed(Key::Enter);
+    bool isEscapePressed = _input.isKeyPressed(Key::Escape);
+    bool isLeftPressed = _input.isKeyPressed(Key::Left);
+    bool isRightPressed = _input.isKeyPressed(Key::Right);
+    bool isUpPressed = _input.isKeyPressed(Key::Up);
+    bool isDownPressed = _input.isKeyPressed(Key::Down);
+
+    if (isAnyInputFieldActive()) {
+        _wasTabPressed = isTabPressed;
+        _wasShiftPressed = isShiftPressed;
+        _wasEnterPressed = isEnterPressed;
+        _wasEscapePressed = isEscapePressed;
+        _wasLeftPressed = isLeftPressed;
+        _wasRightPressed = isRightPressed;
+        _wasUpPressed = isUpPressed;
+        _wasDownPressed = isDownPressed;
+
+        for (auto& field : _inputFields) {
+            if (field.update(mouseX, mouseY, isMousePressed)) {
+                SoundManager::getInstance().playSound("click");
+            }
+        }
+
+        return false;
+    }
+    if (!anyInEditMode) {
+        if (isUpPressed && !_wasUpPressed) {
+            SoundManager::getInstance().playSoundAtVolume("click", 30.0f);
+            _focusedElementIndex--;
+            if (_focusedElementIndex < 0) {
+                _focusedElementIndex = _totalFocusableElements;
+            }
+        }
+        if (isDownPressed && !_wasDownPressed) {
+            SoundManager::getInstance().playSoundAtVolume("click", 30.0f);
+            _focusedElementIndex++;
+            if (_focusedElementIndex > _totalFocusableElements) {
+                _focusedElementIndex = 0;
+            }
+        }
+
+        if ((isEscapePressed && !_wasEscapePressed) ||
+            (isEnterPressed && !_wasEnterPressed &&
+             _focusedElementIndex == _totalFocusableElements)) {
+            SoundManager::getInstance().playSound("click");
+            saveSettings();
+            _wasEscapePressed = isEscapePressed;
+            _wasEnterPressed = isEnterPressed;
+            return true;
+        }
+
+        int currentIndex = 0;
+
+        for (size_t i = 0; i < _resolutionButtons.size(); i++, currentIndex++) {
+            if (currentIndex == _focusedElementIndex && isEnterPressed &&
+                !_wasEnterPressed) {
+                SoundManager::getInstance().playSound("click");
+                _currentResolution = _resolutionButtons[i].getResolution();
+                for (auto& btn : _resolutionButtons) {
+                    btn.setActive(btn.getResolution() == _currentResolution);
+                }
+                int width = getResolutionWidth(_currentResolution);
+                int height = getResolutionHeight(_currentResolution);
+                _window.setResolution(width, height);
+                _config.setInt("resolutionWidth", width);
+                _config.setInt("resolutionHeight", height);
+                _config.save();
+                updateLayout();
+                _totalFocusableElements = static_cast<int>(
+                    _resolutionButtons.size() + _sliders.size() +
+                    _keyBindingButtons.size() + _inputFields.size() + 2);
+            }
+        }
+
+        if (currentIndex == _focusedElementIndex && isEnterPressed &&
+            !_wasEnterPressed) {
+            SoundManager::getInstance().playSound("click");
+            _fullscreenToggle.setOn(!_fullscreenToggle.isOn());
+            _window.setFullscreen(_fullscreenToggle.isOn());
+            _config.setInt("fullscreen", _fullscreenToggle.isOn() ? 1 : 0);
+            _config.save();
+            updateLayout();
+            _totalFocusableElements = static_cast<int>(
+                _resolutionButtons.size() + _sliders.size() +
+                _keyBindingButtons.size() + _inputFields.size() + 2);
+        }
+        currentIndex++;
+
+        if (currentIndex == _focusedElementIndex) {
+            if ((isLeftPressed && !_wasLeftPressed) ||
+                (isRightPressed && !_wasRightPressed)) {
+                SoundManager::getInstance().playSound("click");
+                if (isLeftPressed) {
+                    _colorBlindSelection.cyclePrevious();
+                } else {
+                    _colorBlindSelection.cycleNext();
+                }
+                int selectedMode = _colorBlindSelection.getSelectedIndex();
+                _colorBlindFilter.setMode(
+                    ColorBlindFilter::indexToMode(selectedMode));
+                _config.setInt("colorBlindMode", selectedMode);
+                _config.save();
+            }
+        }
+        currentIndex++;
+
+        for (size_t i = 0; i < _sliders.size(); i++, currentIndex++) {
+            if (currentIndex == _focusedElementIndex) {
+                if (isLeftPressed || isRightPressed) {
+                    float delta = 5.0f;
+                    float newValue = _sliders[i].getValue();
+                    if (isLeftPressed) {
+                        newValue -= delta;
+                    } else {
+                        newValue += delta;
+                    }
+                    newValue = std::max(0.0f, std::min(100.0f, newValue));
+                    _sliders[i].setValue(newValue);
+                    SoundManager::getInstance().playSoundAtVolume("click",
+                                                                  newValue);
+                    if (i == 0) {
+                        SoundManager::getInstance().setMusicVolume(newValue);
+                    } else if (i == 1) {
+                        SoundManager::getInstance().setVolume(newValue);
+                    }
+                }
+            }
+        }
+
+        for (size_t i = 0; i < _inputFields.size(); i++, currentIndex++) {
+            if (currentIndex == _focusedElementIndex && isEnterPressed &&
+                !_wasEnterPressed) {
+                SoundManager::getInstance().playSound("click");
+                _inputFields[i].setActive(true);
+            }
+        }
+
+        for (size_t i = 0; i < _keyBindingButtons.size(); i++, currentIndex++) {
+            if (currentIndex == _focusedElementIndex && isEnterPressed &&
+                !_wasEnterPressed) {
+                SoundManager::getInstance().playSound("click");
+                _keyBindingButtons[i].startEdit();
+            }
+        }
+    }
+
+    _wasTabPressed = isTabPressed;
+    _wasShiftPressed = isShiftPressed;
+    _wasEnterPressed = isEnterPressed;
+    _wasEscapePressed = isEscapePressed;
+    _wasLeftPressed = isLeftPressed;
+    _wasRightPressed = isRightPressed;
+    _wasUpPressed = isUpPressed;
+    _wasDownPressed = isDownPressed;
 
     if (!anyInEditMode) {
         for (size_t i = 0; i < _sliders.size(); ++i) {
@@ -358,6 +528,7 @@ void SettingsMenu::handleKeyPress(Key key)
         for (auto& field : _inputFields) {
             if (field.isActive()) {
                 field.handleEnter();
+                _wasEnterPressed = true;
                 return;
             }
         }
@@ -517,8 +688,10 @@ void SettingsMenu::renderBackButton(float scale)
 {
     unsigned int fontSize = static_cast<unsigned int>(24 * scale);
 
+    bool isFocused = (_focusedElementIndex == _totalFocusableElements);
+
     unsigned char r, g, b;
-    if (_backButton.getIsHovered()) {
+    if (isFocused || _backButton.getIsHovered()) {
         r = 0;
         g = 200;
         b = 255;
@@ -532,21 +705,25 @@ void SettingsMenu::renderBackButton(float scale)
                             _backButton.getWidth(), _backButton.getHeight(), r,
                             g, b);
 
-    float borderThickness = 3.0f * scale;
+    float borderThickness = isFocused ? 5.0f * scale : 3.0f * scale;
+    unsigned char borderR = isFocused ? 255 : 100;
+    unsigned char borderG = isFocused ? 215 : 150;
+    unsigned char borderB = isFocused ? 0 : 255;
+
     _graphics.drawRectangle(_backButton.getX(), _backButton.getY(),
-                            _backButton.getWidth(), borderThickness, 100, 150,
-                            255);
+                            _backButton.getWidth(), borderThickness, borderR,
+                            borderG, borderB);
     _graphics.drawRectangle(
         _backButton.getX(),
         _backButton.getY() + _backButton.getHeight() - borderThickness,
-        _backButton.getWidth(), borderThickness, 100, 150, 255);
+        _backButton.getWidth(), borderThickness, borderR, borderG, borderB);
     _graphics.drawRectangle(_backButton.getX(), _backButton.getY(),
-                            borderThickness, _backButton.getHeight(), 100, 150,
-                            255);
+                            borderThickness, _backButton.getHeight(), borderR,
+                            borderG, borderB);
     _graphics.drawRectangle(
         _backButton.getX() + _backButton.getWidth() - borderThickness,
-        _backButton.getY(), borderThickness, _backButton.getHeight(), 100, 150,
-        255);
+        _backButton.getY(), borderThickness, _backButton.getHeight(), borderR,
+        borderG, borderB);
 
     float textWidth =
         _graphics.getTextWidth(_backButton.getText(), fontSize, _fontPath);
@@ -568,9 +745,24 @@ void SettingsMenu::renderSlider(const Slider& slider, float)
     float handleHeight = baseUnit * 0.45f;
     float fontSize = baseUnit * 0.4f;
 
+    int sliderIndex = 0;
+    bool isFocused = false;
+    int currentIndex = static_cast<int>(_resolutionButtons.size()) + 2;
+    for (size_t i = 0; i < _sliders.size(); i++) {
+        if (&slider == &_sliders[i]) {
+            sliderIndex = static_cast<int>(i);
+            isFocused = (_focusedElementIndex == currentIndex + sliderIndex);
+            break;
+        }
+    }
+
+    unsigned char titleR = isFocused ? 255 : 255;
+    unsigned char titleG = isFocused ? 215 : 255;
+    unsigned char titleB = isFocused ? 0 : 255;
+
     _graphics.drawText(
         slider.getLabel(), slider.getX(), slider.getY() - baseUnit * 0.9f,
-        static_cast<unsigned int>(fontSize), 255, 255, 255, _fontPath);
+        static_cast<unsigned int>(fontSize), titleR, titleG, titleB, _fontPath);
 
     _graphics.drawRectangle(slider.getX(), slider.getY(), slider.getWidth(),
                             trackHeight, 50, 50, 50);
@@ -585,7 +777,11 @@ void SettingsMenu::renderSlider(const Slider& slider, float)
     float handleY = slider.getY() - (handleHeight - trackHeight) / 2.0f;
 
     unsigned char hr, hg, hb;
-    if (slider.isHovered() || slider.isDragging()) {
+    if (isFocused) {
+        hr = 255;
+        hg = 215;
+        hb = 0;
+    } else if (slider.isHovered() || slider.isDragging()) {
         hr = 100;
         hg = 220;
         hb = 255;
@@ -643,17 +839,41 @@ void SettingsMenu::saveSettings()
     _config.save();
 }
 
+void SettingsMenu::reset()
+{
+    _focusedElementIndex = 0;
+    _wasTabPressed = false;
+    _wasShiftPressed = false;
+    _wasEnterPressed = true;
+    _wasEscapePressed = false;
+    _wasLeftPressed = false;
+    _wasRightPressed = false;
+    _wasUpPressed = false;
+    _wasDownPressed = false;
+}
+
 void SettingsMenu::renderKeyBindingButton(const KeyBindingButton& button,
                                           float scale)
 {
     unsigned int fontSize = static_cast<unsigned int>(24 * scale);
+
+    bool isFocused = false;
+    int currentIndex = static_cast<int>(
+        _resolutionButtons.size() + _sliders.size() + _inputFields.size() + 2);
+    for (size_t i = 0; i < _keyBindingButtons.size(); i++) {
+        if (&button == &_keyBindingButtons[i]) {
+            isFocused =
+                (_focusedElementIndex == currentIndex + static_cast<int>(i));
+            break;
+        }
+    }
 
     unsigned char r, g, b;
     if (button.isInEditMode()) {
         r = 255;
         g = 180;
         b = 0;
-    } else if (button.getIsHovered()) {
+    } else if (isFocused || button.getIsHovered()) {
         r = 0;
         g = 200;
         b = 255;
@@ -666,9 +886,14 @@ void SettingsMenu::renderKeyBindingButton(const KeyBindingButton& button,
     _graphics.drawRectangle(button.getX(), button.getY(), button.getWidth(),
                             button.getHeight(), r, g, b);
 
-    float borderThickness = 3.0f * scale;
+    float borderThickness =
+        (button.isInEditMode() || isFocused ? 4.0f : 3.0f) * scale;
+    unsigned char borderR = isFocused && !button.isInEditMode() ? 255 : 100;
+    unsigned char borderG = isFocused && !button.isInEditMode() ? 215 : 150;
+    unsigned char borderB = isFocused && !button.isInEditMode() ? 0 : 255;
+
     _graphics.drawRectangle(button.getX(), button.getY(), button.getWidth(),
-                            borderThickness, 100, 150, 255);
+                            borderThickness, borderR, borderG, borderB);
     _graphics.drawRectangle(
         button.getX(), button.getY() + button.getHeight() - borderThickness,
         button.getWidth(), borderThickness, 100, 150, 255);
@@ -701,8 +926,11 @@ void SettingsMenu::renderToggleButton(float scale)
 {
     unsigned int fontSize = static_cast<unsigned int>(24 * scale);
 
+    bool isFocused =
+        (_focusedElementIndex == static_cast<int>(_resolutionButtons.size()));
+
     unsigned char r, g, b;
-    if (_fullscreenToggle.getIsHovered()) {
+    if (isFocused || _fullscreenToggle.getIsHovered()) {
         r = 0;
         g = 200;
         b = 255;
@@ -716,22 +944,27 @@ void SettingsMenu::renderToggleButton(float scale)
                             _fullscreenToggle.getWidth(),
                             _fullscreenToggle.getHeight(), r, g, b);
 
-    float borderThickness = 3.0f * scale;
+    float borderThickness = isFocused ? 5.0f * scale : 3.0f * scale;
+    unsigned char borderR = isFocused ? 255 : 100;
+    unsigned char borderG = isFocused ? 215 : 150;
+    unsigned char borderB = isFocused ? 0 : 255;
+
     _graphics.drawRectangle(_fullscreenToggle.getX(), _fullscreenToggle.getY(),
-                            _fullscreenToggle.getWidth(), borderThickness, 100,
-                            150, 255);
+                            _fullscreenToggle.getWidth(), borderThickness,
+                            borderR, borderG, borderB);
     _graphics.drawRectangle(_fullscreenToggle.getX(),
                             _fullscreenToggle.getY() +
                                 _fullscreenToggle.getHeight() - borderThickness,
-                            _fullscreenToggle.getWidth(), borderThickness, 100,
-                            150, 255);
+                            _fullscreenToggle.getWidth(), borderThickness,
+                            borderR, borderG, borderB);
     _graphics.drawRectangle(_fullscreenToggle.getX(), _fullscreenToggle.getY(),
-                            borderThickness, _fullscreenToggle.getHeight(), 100,
-                            150, 255);
+                            borderThickness, _fullscreenToggle.getHeight(),
+                            borderR, borderG, borderB);
     _graphics.drawRectangle(_fullscreenToggle.getX() +
                                 _fullscreenToggle.getWidth() - borderThickness,
                             _fullscreenToggle.getY(), borderThickness,
-                            _fullscreenToggle.getHeight(), 100, 150, 255);
+                            _fullscreenToggle.getHeight(), borderR, borderG,
+                            borderB);
 
     _graphics.drawText(_fullscreenToggle.getLabel(),
                        _fullscreenToggle.getX() + 20.0f * scale,
@@ -757,12 +990,20 @@ void SettingsMenu::renderResolutionButton(const ResolutionButton& button,
 {
     unsigned int fontSize = static_cast<unsigned int>(24 * scale);
 
+    bool isFocused = false;
+    for (size_t i = 0; i < _resolutionButtons.size(); i++) {
+        if (&button == &_resolutionButtons[i]) {
+            isFocused = (_focusedElementIndex == static_cast<int>(i));
+            break;
+        }
+    }
+
     unsigned char r, g, b;
     if (button.isActive()) {
         r = 0;
         g = 200;
         b = 50;
-    } else if (button.getIsHovered()) {
+    } else if (isFocused || button.getIsHovered()) {
         r = 0;
         g = 200;
         b = 255;
@@ -774,10 +1015,11 @@ void SettingsMenu::renderResolutionButton(const ResolutionButton& button,
 
     _graphics.drawRectangle(button.getX(), button.getY(), button.getWidth(),
                             button.getHeight(), r, g, b);
-    float borderThickness = (button.isActive() ? 4.0f : 3.0f) * scale;
-    unsigned char borderR = button.isActive() ? 0 : 100;
-    unsigned char borderG = button.isActive() ? 255 : 150;
-    unsigned char borderB = button.isActive() ? 100 : 255;
+    float borderThickness =
+        (button.isActive() || isFocused ? 4.0f : 3.0f) * scale;
+    unsigned char borderR = isFocused ? 255 : (button.isActive() ? 0 : 100);
+    unsigned char borderG = isFocused ? 215 : (button.isActive() ? 255 : 150);
+    unsigned char borderB = isFocused ? 0 : (button.isActive() ? 100 : 255);
 
     _graphics.drawRectangle(button.getX(), button.getY(), button.getWidth(),
                             borderThickness, borderR, borderG, borderB);
@@ -803,11 +1045,14 @@ void SettingsMenu::renderColorBlindSelection(float scale)
 {
     unsigned int fontSize = static_cast<unsigned int>(24 * scale);
 
-    unsigned char r, g, b;
     int mouseX = _input.getMouseX();
     int mouseY = _input.getMouseY();
 
-    if (_colorBlindSelection.isHovered(mouseX, mouseY)) {
+    bool isFocused = (_focusedElementIndex ==
+                      static_cast<int>(_resolutionButtons.size()) + 1);
+
+    unsigned char r, g, b;
+    if (isFocused || _colorBlindSelection.isHovered(mouseX, mouseY)) {
         r = 0;
         g = 200;
         b = 255;
@@ -822,23 +1067,30 @@ void SettingsMenu::renderColorBlindSelection(float scale)
                             _colorBlindSelection.getWidth(),
                             _colorBlindSelection.getHeight(), r, g, b);
 
-    float borderThickness = 3.0f * scale;
-    _graphics.drawRectangle(
-        _colorBlindSelection.getX(), _colorBlindSelection.getY(),
-        _colorBlindSelection.getWidth(), borderThickness, 100, 150, 255);
-    _graphics.drawRectangle(
-        _colorBlindSelection.getX(),
-        _colorBlindSelection.getY() + _colorBlindSelection.getHeight() -
-            borderThickness,
-        _colorBlindSelection.getWidth(), borderThickness, 100, 150, 255);
+    float borderThickness = isFocused ? 5.0f * scale : 3.0f * scale;
+    unsigned char borderR = isFocused ? 255 : 100;
+    unsigned char borderG = isFocused ? 215 : 150;
+    unsigned char borderB = isFocused ? 0 : 255;
+
+    _graphics.drawRectangle(_colorBlindSelection.getX(),
+                            _colorBlindSelection.getY(),
+                            _colorBlindSelection.getWidth(), borderThickness,
+                            borderR, borderG, borderB);
+    _graphics.drawRectangle(_colorBlindSelection.getX(),
+                            _colorBlindSelection.getY() +
+                                _colorBlindSelection.getHeight() -
+                                borderThickness,
+                            _colorBlindSelection.getWidth(), borderThickness,
+                            borderR, borderG, borderB);
     _graphics.drawRectangle(_colorBlindSelection.getX(),
                             _colorBlindSelection.getY(), borderThickness,
-                            _colorBlindSelection.getHeight(), 100, 150, 255);
-    _graphics.drawRectangle(_colorBlindSelection.getX() +
-                                _colorBlindSelection.getWidth() -
-                                borderThickness,
-                            _colorBlindSelection.getY(), borderThickness,
-                            _colorBlindSelection.getHeight(), 100, 150, 255);
+                            _colorBlindSelection.getHeight(), borderR, borderG,
+                            borderB);
+    _graphics.drawRectangle(
+        _colorBlindSelection.getX() + _colorBlindSelection.getWidth() -
+            borderThickness,
+        _colorBlindSelection.getY(), borderThickness,
+        _colorBlindSelection.getHeight(), borderR, borderG, borderB);
 
     std::string displayText = _colorBlindSelection.getSelectedOption();
     float textWidth = _graphics.getTextWidth(displayText, fontSize, _fontPath);
@@ -853,12 +1105,23 @@ void SettingsMenu::renderInputField(const InputField& field, float scale)
 {
     unsigned int fontSize = static_cast<unsigned int>(20 * scale);
 
+    bool isFocused = false;
+    int currentIndex =
+        static_cast<int>(_resolutionButtons.size() + _sliders.size() + 2);
+    for (size_t i = 0; i < _inputFields.size(); i++) {
+        if (&field == &_inputFields[i]) {
+            isFocused =
+                (_focusedElementIndex == currentIndex + static_cast<int>(i));
+            break;
+        }
+    }
+
     unsigned char r, g, b;
     if (field.isActive()) {
         r = 255;
         g = 180;
         b = 0;
-    } else if (field.getIsHovered()) {
+    } else if (isFocused || field.getIsHovered()) {
         r = 0;
         g = 200;
         b = 255;
@@ -871,10 +1134,14 @@ void SettingsMenu::renderInputField(const InputField& field, float scale)
     _graphics.drawRectangle(field.getX(), field.getY(), field.getWidth(),
                             field.getHeight(), r, g, b);
 
-    float borderThickness = 3.0f * scale;
-    unsigned char borderR = field.isActive() ? 255 : 100;
-    unsigned char borderG = field.isActive() ? 180 : 150;
-    unsigned char borderB = field.isActive() ? 0 : 255;
+    float borderThickness =
+        (field.isActive() || isFocused ? 4.0f : 3.0f) * scale;
+    unsigned char borderR =
+        isFocused && !field.isActive() ? 255 : (field.isActive() ? 255 : 100);
+    unsigned char borderG =
+        isFocused && !field.isActive() ? 215 : (field.isActive() ? 180 : 150);
+    unsigned char borderB =
+        isFocused && !field.isActive() ? 0 : (field.isActive() ? 0 : 255);
 
     _graphics.drawRectangle(field.getX(), field.getY(), field.getWidth(),
                             borderThickness, borderR, borderG, borderB);

--- a/client/SettingsMenu.hpp
+++ b/client/SettingsMenu.hpp
@@ -80,6 +80,11 @@ class SettingsMenu {
      */
     void saveSettings();
 
+    /**
+     * @brief Reset keyboard state (call when entering settings menu)
+     */
+    void reset();
+
    private:
     enum class SettingsInputField { ServerAddress = 0, ServerPort = 1 };
 
@@ -101,6 +106,17 @@ class SettingsMenu {
     KeyBinding& _keyBinding;
     ColorBlindFilter& _colorBlindFilter;
     Resolution _currentResolution;
+
+    int _focusedElementIndex;
+    int _totalFocusableElements;
+    bool _wasTabPressed;
+    bool _wasShiftPressed;
+    bool _wasEnterPressed;
+    bool _wasEscapePressed;
+    bool _wasLeftPressed;
+    bool _wasRightPressed;
+    bool _wasUpPressed;
+    bool _wasDownPressed;
 
     static constexpr float SLIDER_WIDTH = 400.0f;
     static constexpr float SLIDER_SPACING = 100.0f;

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -89,6 +89,7 @@ int main()
                     break;
                 case MenuAction::Settings:
                     state = GameState::Settings;
+                    settingsMenu->reset();
                     break;
                 case MenuAction::Quit:
                     window->close();


### PR DESCRIPTION
This pull request adds comprehensive keyboard navigation and focus management to the main menu and settings menu, improving accessibility and user experience. The changes introduce keyboard focus state to buttons, allow navigation between UI elements using arrow keys and other keyboard shortcuts, and provide visual feedback for focused elements. Additionally, utility functions for cycling selection options and entering edit modes are added to relevant UI components.

**Keyboard navigation and focus management:**

* Added keyboard focus state to `Button` and enabled setting/getting focus via new methods (`_isFocused`, `setFocused`, `getIsFocused`) in `Button.hpp` and updated logic in `Button.cpp` to visually and functionally distinguish focused buttons. [[1]](diffhunk://#diff-374617d1e03bfd27f187e7cd8d93b509a22ec9641478b487a78f54fa3fcac2f0R27) [[2]](diffhunk://#diff-374617d1e03bfd27f187e7cd8d93b509a22ec9641478b487a78f54fa3fcac2f0L51-R52) [[3]](diffhunk://#diff-39570aa16b7b45816bdf72cc6425154aec25c4e5b3d1cc35ad82960cbe5fd7c9R66-R72) [[4]](diffhunk://#diff-39570aa16b7b45816bdf72cc6425154aec25c4e5b3d1cc35ad82960cbe5fd7c9R96)
* Implemented keyboard navigation in `Menu.cpp` to allow users to move between buttons using the up/down arrow keys and activate them with Enter, including visual focus indication and sound feedback. Mouse hover updates focus as well. [[1]](diffhunk://#diff-e6ea314e0669d7187f42036d9855159597bf04d956013a94f70b0df04d25aa1bR24-R27) [[2]](diffhunk://#diff-e6ea314e0669d7187f42036d9855159597bf04d956013a94f70b0df04d25aa1bR36-R39) [[3]](diffhunk://#diff-e6ea314e0669d7187f42036d9855159597bf04d956013a94f70b0df04d25aa1bR94-R98) [[4]](diffhunk://#diff-e6ea314e0669d7187f42036d9855159597bf04d956013a94f70b0df04d25aa1bR122-R177) [[5]](diffhunk://#diff-e6ea314e0669d7187f42036d9855159597bf04d956013a94f70b0df04d25aa1bL159-R225) [[6]](diffhunk://#diff-8491723a2172b9a2cf7ec8705ab819f50cba8bd55f6ae872e027eb886197a729R90-R94)
* Enhanced `SettingsMenu.cpp` to support keyboard navigation across all focusable elements (resolution buttons, sliders, key binding buttons, input fields, and the back button), with logic to handle focus movement, activation, and visual cues for focused elements. [[1]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fL35-R45) [[2]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fR80-R82) [[3]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fR277-R434) [[4]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fR531) [[5]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fR691-R694) [[6]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fL535-R726) [[7]](diffhunk://#diff-0cda3c940dc03d26a82045d17a67ed3f04ea121f36c956c24b0d171421020a5fR748-R765)

**UI component improvements:**

* Added `cycleNext` and `cyclePrevious` methods to `SelectionButton` for cycling through options using keyboard navigation. [[1]](diffhunk://#diff-4d701856ac35f687fd5beb57d33c4dc2b39dd6b26c070c0d746ad85ddd718f3cR61-R77) [[2]](diffhunk://#diff-b9c77ee9527caad2ea3cc89793571f69594249b5c10d8ef7a9514f116b691d35R61-R70)
* Added `startEdit` method to `KeyBindingButton` to allow entering edit mode via keyboard, facilitating keyboard-only configuration.

These changes collectively make the UI navigable and operable via keyboard, enhancing accessibility and usability for all users.