### PR TITLE
[FIX] update player bounding box dimensions for improved collision de…

### DIFF
--- a/client/src/Game.cpp
+++ b/client/src/Game.cpp
@@ -365,18 +365,21 @@ void Game::render()
                 }
 
                 if (_showHitboxes) {
-                    static const std::unordered_map<uint8_t,
-                                                    std::pair<float, float>>
-                        hitboxSizes = {
-                            {1, {80.0f, 68.0f}},   {2, {56.0f, 56.0f}},
-                            {3, {114.0f, 36.0f}},  {4, {114.0f, 36.0f}},
-                            {5, {260.0f, 100.0f}}, {6, {48.0f, 34.5f}}};
+                    static const std::unordered_map<
+                        uint8_t, std::tuple<float, float, float, float>>
+                        hitboxData = {{1, {100.0f, 50.0f, 20.0f, 17.0f}},
+                                      {2, {56.0f, 56.0f, 0.0f, 0.0f}},
+                                      {3, {114.0f, 36.0f, 0.0f, 0.0f}},
+                                      {4, {114.0f, 36.0f, 0.0f, 0.0f}},
+                                      {5, {260.0f, 100.0f, 0.0f, 0.0f}},
+                                      {6, {48.0f, 34.5f, 0.0f, 0.0f}}};
 
-                    auto it = hitboxSizes.find(entity->type);
-                    if (it != hitboxSizes.end()) {
-                        const auto& [hitboxWidth, hitboxHeight] = it->second;
-                        float hbX = sx;
-                        float hbY = sy;
+                    auto it = hitboxData.find(entity->type);
+                    if (it != hitboxData.end()) {
+                        const auto& [hitboxWidth, hitboxHeight, offsetX,
+                                     offsetY] = it->second;
+                        float hbX = sx + offsetX * windowScale;
+                        float hbY = sy + offsetY * windowScale;
                         float hbW = hitboxWidth * windowScale;
                         float hbH = hitboxHeight * windowScale;
 

--- a/server/engine/entity/GameEntityFactory.cpp
+++ b/server/engine/entity/GameEntityFactory.cpp
@@ -28,7 +28,8 @@ Entity GameEntityFactory::createPlayer(uint32_t clientId, uint32_t playerId,
     _entityManager.addComponent(player, Velocity(0.0f, 0.0f));
     _entityManager.addComponent(player, Player(clientId, playerId));
     _entityManager.addComponent(player, Health(100.0f));
-    _entityManager.addComponent(player, BoundingBox(35.0f, 21.0f, 0.0f, 0.0f));
+    _entityManager.addComponent(player,
+                                BoundingBox(100.0f, 50.0f, 20.0f, 17.0f));
     _entityManager.addComponent(player,
                                 NetworkEntity(playerId, EntityType::PLAYER));
 


### PR DESCRIPTION
This pull request updates the hitbox dimensions and offsets for player entities to ensure consistency between the client and server. The changes modify both the rendering of hitboxes on the client and the bounding box component for players on the server.

**Hitbox and bounding box updates:**

* Updated the client-side hitbox rendering logic in `Game.cpp` to use a new data structure that includes both hitbox size and offset, ensuring hitboxes are drawn at the correct position and with the correct dimensions.
* Modified the server-side player entity creation in `GameEntityFactory.cpp` to set the player's `BoundingBox` component to match the new hitbox size and offset used on the client, improving consistency between client rendering and server-side collision detection.…tection